### PR TITLE
Fixed a few issues

### DIFF
--- a/css/grayscale.css
+++ b/css/grayscale.css
@@ -584,10 +584,9 @@ a:focus {
 .box-2 {
   background:#eeeeee;
   position: absolute;
-  width: 60%;
   height: 250px;
-  left: 20%;
-  right: 20%;
+  left: 10%;
+  right: 10%;
   margin-top:80px;
   padding-bottom:30px;
   -webkit-box-shadow: 0px 0px 26px 3px rgba(0,0,0,0.47);
@@ -829,4 +828,10 @@ img::-moz-selection {
 }
 body {
   webkit-tap-highlight-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Carousel Overrides */
+.carousel-inner {
+  top: 50%;
+  transform: translateY(-50%);
 }

--- a/css/grayscale.css
+++ b/css/grayscale.css
@@ -486,7 +486,6 @@ a:focus {
   background-size: cover;
   -o-background-size: cover;
   background-blend-mode: screen;
-  margin-top:-100px;
   z-index:-2;
 }
 
@@ -499,24 +498,21 @@ a:focus {
   background-size: cover;
   -o-background-size: cover;
   background-blend-mode: screen;
-  margin-top:-350px;
-  padding-bottom:400px;
   z-index:-3;
 }
 
 .service-image-3 .triangle-left{
-  float:left;
+  position: absolute;
+  left: 0px;
+  top: 0px;
   width:50%;
 }
 
 .service-image-3 .triangle-right{
-  float:right;
-  width:50%;
-}
-
-.service-image-3 .inner{
-  position:absolute;
-  padding-top:300px;
+  position: absolute;
+  right: 0px;
+  bottom: 0px;
+  width: 50%;
 }
 
 .service-image-4{
@@ -531,7 +527,6 @@ a:focus {
   border-style:dashed;
   border-width:3px 0 0 0;
   border-color:#1f1f1e;
-  margin-top:-350px;
 }
 
 .client-section {

--- a/css/grayscale.css
+++ b/css/grayscale.css
@@ -780,7 +780,7 @@ ul.banner-social-buttons {
   }
 }
 footer {
-  padding: 50px 50px 0 50px;
+  padding: 50px 0;
 }
 footer h1{
   font-size:18px;

--- a/index.html
+++ b/index.html
@@ -262,27 +262,27 @@
         <div class="client-container">
             <div class="row align-items-center align-self-center">            
                 <div class="col-md-12"><br><br>
-                    <div class="col-lg-2 col-sm-12">
+                    <div class="col-sm-2 col-sm-12">
                         <img class="img-responsive" alt="" src="img/clients/firstgroup.png" />
                     </div>
 
-                    <div class="col-lg-2 col-sm-12">
+                    <div class="col-sm-2 col-sm-12">
                         <img class="img-responsive" alt="" src="img/clients/arriva.png" />
                     </div>
 
-                    <div class="col-lg-2 col-sm-12">
+                    <div class="col-sm-2 col-sm-12">
                         <img class="img-responsive" alt="" src="img/clients/angeltrains.png" />
                     </div>
 
-                    <div class="col-lg-2 col-sm-12">
+                    <div class="col-sm-2 col-sm-12">
                         <img class="img-responsive" alt="" src="img/clients/trainline.png" />
                     </div>
 
-                    <div class="col-lg-2 col-sm-12">
+                    <div class="col-sm-2 col-sm-12">
                         <img class="img-responsive" alt="" src="img/clients/baesystems.png" />
                     </div>
 
-                    <div class="col-lg-2 col-sm-12">
+                    <div class="col-sm-2 col-sm-12">
                         <img class="img-responsive" alt="" src="img/clients/dft.png" />
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -349,11 +349,13 @@
             <div class="box-2 wow pulse" data-wow-duration="2s">
                 <div class="text-center">
                     <div id="carousel" class="carousel slide" data-ride="carousel">
+                        <!--
                         <ol class="carousel-indicators">
                             <li data-target="#carousel" data-slide-to="0" class="active"></li>
                             <li data-target="#carousel" data-slide-to="1"></li>
                             <li data-target="#carousel" data-slide-to="2"></li>
                         </ol>
+                        -->
 
                         <div class="carousel-inner">
                             <div class="item active">


### PR DESCRIPTION
- Hackathons isn't responsive
	> Removed margin and paddings that move the sections around
	> Swapped out float: left/right on the images in favor of absolute positioning. Getting float positioning to work nicely is a bit of a dark art, it's easier in this case to specify the image's position directly. If an element has `position: absolute` and its parent has `position: relative`, then we can set the child's position relative to its container using `top/right/bottom/left` values.
- Client stacking issue
	> Replaced col-lg-2 with col-sm-2 in first row to match others
- Testimonial carousel text overflows background at certain dimensions
	> If we want a fixed hight, we will always have to deal with content overflow. There's multiple solutions: increase width, reduce content size like font size, or increase height. I went for increasing width.
- Testimonial carousel content isn't nicely centered
	> Vertically centered content
- Testimonial carousel page indicators overlay text and aren't clear with white background
	> Removed them because I'm not convinced they're that helpful
- Centred footer content better (was shifted to the right a little)